### PR TITLE
Added setExtraHeader and setTimeout method and fixes depreciation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ AxioQL.setQLEndpoint('https://graphql.server.com/graphql');
 // If you have to authenticate use this method to set the header
 AxioQL.setAuthHeader('Bearer #sometoken#');
 
+// If you wish to add fields to the HTTP header use this method
+AxioQL.setExtraHeader('someHeaderFieldName', 'some value');
+
+
 // Create a query
 const someQuery = `query ($searchText: String!) {
   productSearch(title: $searchText) {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,18 @@
   "scripts": {
     "lint": "eslint .",
     "flow": "flow check .",
-    "prepublish": "mkdir dist && babel ./src --out-dir ./dist"
+    "prepublish": "rm -frd ./dist && mkdir dist && babel ./src --out-dir ./dist"
   },
   "devDependencies": {
     "@shopsterdotio/eslint-config": "^1.0.3",
     "babel-cli": "^6.23.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
     "babel-plugin-module-resolver": "^2.5.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-preset-es2015": "^6.22.0",
-    "babel-preset-stage-0": "^6.22.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "flow-bin": "^0.41.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "axios": "^0.15.3",
+    "graphql": "^0.10.5",
     "graphql-tag": "^1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axioql",
   "description": "GraphQL client that uses axios under the hood.",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "repository": "https://github.com/urbancvek/axioql",
   "license": "MIT",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,10 @@
   "devDependencies": {
     "@shopsterdotio/eslint-config": "^1.0.3",
     "babel-cli": "^6.23.0",
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
     "babel-plugin-module-resolver": "^2.5.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-stage-0": "^6.22.0",
     "flow-bin": "^0.41.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,14 @@ class AxioQL {
     this.authHeader = header;
   }
 
+  setExtraHeader(headerName: string, value: string) {
+    // Create extraHeaders property if it doens't exist
+    if (!this.extraHeaders) {
+      this.extraHeaders = {};
+    }
+    this.extraHeaders[headerName] = value;
+  }
+
   async request({ query, variables }: Request = { query: null, variables: null }) {
     if (!query) throw new Error('Query is required!');
     if (!this.endpoint) throw new Error('Endpoint is required. Use AxioQL.setQLEndpoint(endpoint: string) method.');
@@ -31,7 +39,7 @@ class AxioQL {
       const response = await axios.post(
         this.endpoint,
         { query: modifiedQuery, variables: stringifiedVariables },
-        this.authHeader ? { headers: { 'Authorization': this.authHeader } } : {},
+        this.authHeader ? { headers: { ...this.extraHeaders, Authorization: this.authHeader } } : {},
       );
 
       return response;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ type Request = {
 class AxioQL {
   endpoint: ?string;
   authHeader: ?string;
+  extraHeaders: ?Object;
+  timeout: ?number;
 
   setQLEndpoint(endpoint: string) {
     this.endpoint = endpoint;
@@ -28,6 +30,10 @@ class AxioQL {
     this.extraHeaders[headerName] = value;
   }
 
+  setTimeout(seconds: number) {
+    this.timeout = seconds;
+  }
+
   async request({ query, variables }: Request = { query: null, variables: null }) {
     if (!query) throw new Error('Query is required!');
     if (!this.endpoint) throw new Error('Endpoint is required. Use AxioQL.setQLEndpoint(endpoint: string) method.');
@@ -40,6 +46,7 @@ class AxioQL {
         this.endpoint,
         { query: modifiedQuery, variables: stringifiedVariables },
         this.authHeader ? { headers: { ...this.extraHeaders, Authorization: this.authHeader } } : {},
+        { timeout: this.timeout ? this.timeout : 1000 }
       );
 
       return response;

--- a/src/queryModifier.js
+++ b/src/queryModifier.js
@@ -1,6 +1,6 @@
 // @flow
 import gql from 'graphql-tag';
-import { print } from 'graphql-tag/printer';
+import { print } from 'graphql/language/printer';
 
 const TYPENAME_FIELD = {
   kind: 'Field',


### PR DESCRIPTION
Pull request fixes the following depreciation warning:

> Warning - the `printer` exports from `graphql-tag` will be removed in the next major version. See https://github.com/apollographql/graphql-tag/issues/54 for more information.